### PR TITLE
Fixing proportion of variance calculation when scale=FALSE

### DIFF
--- a/R/pca.R
+++ b/R/pca.R
@@ -159,7 +159,7 @@ pca <- function(
   if (scale) {
     total.var <- length(vars)
   } else {
-    total.var <- sum(vars)
+    total.var <- sum(pcaobj$sdev ^ 2)
   }
   proportionvar <- (pcaobj$sdev ^ 2) / total.var * 100
 


### PR DESCRIPTION
Switching the calculation to use the sum of variance of the PCs provides a result almost identical to `prcomp` when `scale=FALSE` is set.

prcomp results.

```
> summary(prcomp(mtcars, scale=FALSE, center=FALSE, rank=6))
Importance of first k=6 (out of 11) components:
                            PC1      PC2      PC3     PC4     PC5     PC6
Standard deviation     310.1170 40.88498 15.84946 2.14069 1.01301 0.75598
Proportion of Variance   0.9803  0.01704  0.00256 0.00005 0.00001 0.00001
Cumulative Proportion    0.9803  0.99737  0.99993 0.99998 0.99999 1.00000
```

PCAtools results after fix.

```
> pca(t(mtcars), scale=FALSE, center=FALSE, rank=6)[c("variance", "sdev")]
$variance
         PC1          PC2          PC3          PC4          PC5          PC6 
9.803370e+01 1.703930e+00 2.560667e-01 4.671256e-03 1.046043e-03 5.825718e-04 

$sdev
[1] 310.1170486  40.8849807  15.8494620   2.1406948   1.0130078   0.7559841
```