### PR TITLE
Fixing variation when center=FALSE

### DIFF
--- a/R/pca.R
+++ b/R/pca.R
@@ -128,11 +128,8 @@ pca <- function(
   }
 
   # remove lower portion of variables based on variation
-  if (center) {
-    vars <- colVars(DelayedArray(mat))
-  } else {
-    vars <- colVars(DelayedArray(mat), center = FALSE)
-  }
+  .center <- if (center) NULL else 0
+  vars <- colVars(DelayedArray(mat), center=.center)
 
   if (!is.null(removeVar)) {
     message('-- removing the lower ', removeVar * 100,

--- a/R/pca.R
+++ b/R/pca.R
@@ -128,7 +128,12 @@ pca <- function(
   }
 
   # remove lower portion of variables based on variation
-  vars <- colVars(DelayedArray(mat))
+  if (center) {
+    vars <- colVars(DelayedArray(mat))
+  } else {
+    vars <- colVars(DelayedArray(mat), center = FALSE)
+  }
+
   if (!is.null(removeVar)) {
     message('-- removing the lower ', removeVar * 100,
       '% of variables based on variance')

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -8,6 +8,12 @@ test_that("pca settings work as expected", {
 
     scaled <- pca(lcounts, scale=TRUE)
     expect_equal(as.matrix(scaled$rotated), prcomp(t(lcounts), scale=TRUE)$x)
+
+    not_centered <- pca(lcounts, center=FALSE, rank=10)
+    expect_equal(
+      as.matrix(not_centered$rotated),
+      prcomp(t(lcounts), center=FALSE, rank=10)$x
+    )
     
     trunc <- pca(lcounts, rank=10)
     expect_equal(as.matrix(trunc$rotated), prcomp(t(lcounts), rank=10)$x)
@@ -39,6 +45,12 @@ test_that("percentage of variance calculations are correct", {
     scaled <- pca(lcounts, rank=min(dim(lcounts)), scale=TRUE)
     expect_equal(sum(scaled$variance), 100)
     expect_false(isTRUE(all.equal(scaled, basic)))
+
+    not_centered <- pca(lcounts, center=FALSE, rank=10)
+    expect_equal(
+      round(not_centered$variance, 3),
+      round(summary(prcomp(t(lcounts), center=FALSE, rank=10))$importance[2, seq_len(10)] * 100, 3)
+    )
 
     removed <- pca(lcounts, rank=min(dim(lcounts)), removeVar=0.5)
     expect_equal(sum(removed$variance), 100)

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -48,8 +48,9 @@ test_that("percentage of variance calculations are correct", {
 
     not_centered <- pca(lcounts, center=FALSE, rank=10)
     expect_equal(
-      round(not_centered$variance, 3),
-      round(summary(prcomp(t(lcounts), center=FALSE, rank=10))$importance[2, seq_len(10)] * 100, 3)
+      not_centered$variance,
+      head(summary(prcomp(t(lcounts), center=FALSE, rank=10))$importance[2,], 10) * 100,
+      tolerance=1e-4, check.attributes=TRUE
     )
 
     removed <- pca(lcounts, rank=min(dim(lcounts)), removeVar=0.5)

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -50,7 +50,8 @@ test_that("percentage of variance calculations are correct", {
     expect_equal(
       not_centered$variance,
       head(summary(prcomp(t(lcounts), center=FALSE, rank=10))$importance[2,], 10) * 100,
-      tolerance=1e-4, check.attributes=TRUE
+      tolerance=1e-4, # summary.prcomp rounds to 5th decimal place.
+      check.attributes=TRUE
     )
 
     removed <- pca(lcounts, rank=min(dim(lcounts)), removeVar=0.5)


### PR DESCRIPTION
fixes #31 

Currently setting `center = FALSE` for the `pca` function results in incorrect variance explained values. As Aaron Lun kindly pointed out, this is due to the `DelayedMatrixStats::colVars` centering the data by default. This pull request should fix that problem.

```
> pca(t(mtcars), scale=FALSE, center=FALSE, rank=6)[c("variance", "sdev")]
$variance
         PC1          PC2          PC3          PC4          PC5          PC6 
9.803326e+01 1.703922e+00 2.560656e-01 4.671234e-03 1.046039e-03 5.825692e-04 

$sdev
[1] 310.1170486  40.8849807  15.8494620   2.1406948   1.0130078   0.7559841
```

Results using `stats::prcomp` as comparison.

```
> summary(prcomp(mtcars, scale=FALSE, center=FALSE, rank=6))
Importance of first k=6 (out of 11) components:
                            PC1      PC2      PC3     PC4     PC5     PC6
Standard deviation     310.1170 40.88498 15.84946 2.14069 1.01301 0.75598
Proportion of Variance   0.9803  0.01704  0.00256 0.00005 0.00001 0.00001
Cumulative Proportion    0.9803  0.99737  0.99993 0.99998 0.99999 1.00000
```