### PR TITLE
Use linewidth instead of deprecated size for element_rect

### DIFF
--- a/R/biplot.R
+++ b/R/biplot.R
@@ -521,7 +521,7 @@ biplot <- function(
     theme(panel.border = element_rect(
       colour = borderColour,
       fill = NA,
-      size = borderWidth))
+      linewidth = borderWidth))
 
   # gridlines
   if (gridlines.major == TRUE) {

--- a/R/plotloadings.R
+++ b/R/plotloadings.R
@@ -298,7 +298,7 @@ plotloadings <- function(
     theme(panel.border = element_rect(
       colour = borderColour,
       fill = NA,
-      size = borderWidth))
+      linewidth = borderWidth))
 
   # gridlines
   if (gridlines.major == TRUE) {

--- a/R/screeplot.R
+++ b/R/screeplot.R
@@ -217,7 +217,7 @@ screeplot <- function(
     theme(panel.border = element_rect(
       colour = borderColour,
       fill = NA,
-      size = borderWidth))
+      linewidth = borderWidth))
 
   # gridlines
   if (gridlines.major == TRUE) {


### PR DESCRIPTION
Resolves warnings like:


```
Warning: The `size` argument of `element_rect()` is deprecated as of ggplot2 3.4.0.
ℹ Please use the `linewidth` argument instead.
ℹ The deprecated feature was likely used in the PCAtools package.
  Please report the issue to the authors.
This warning is displayed once every 8 hours.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
generated.
```